### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,0 +1,3 @@
+<?php
+
+$runner->addTestsFromDirectory(__DIR__.'/Tests');

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
 
 before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --dev
 
 script:
-  - vendor/bin/atoum -d Tests
+  - vendor/bin/atoum

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,4 +1,3 @@
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../vendor/atoum/atoum/scripts/runner.php';

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "atoum/atoum": "@stable"
+        "atoum/atoum": "^2.8|^3.0"
     }
 }


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.