### PR TITLE
use http_response_code(403) in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $connAllowed = $firewall
 ;
 
 if (!$connAllowed) {
-    header($_SERVER["SERVER_PROTOCOL"]." 403 Forbiden");
+    http_response_code(403); // Forbiden
     exit();
 }
 ```


### PR DESCRIPTION
looks better, and the function is designed specifically for this operation, and it's probably more future proof, in that, if there's any future version of the http protocol that serves response codes differently, it will be up to the php devs to fix it, not the M6Web/Firewall devs.