### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $connAllowed = $firewall
 ;
 
 if (!$connAllowed) {
-    http_response_code(403); // Forbiden
+    http_response_code(403); // Forbidden
     exit();
 }
 ```


### PR DESCRIPTION
this typo actually predates the repo itself, being present since the very first commit