### PR TITLE
Use bitwise operators instead of iterating over bits

### DIFF
--- a/Entry/AbstractIP.php
+++ b/Entry/AbstractIP.php
@@ -173,12 +173,28 @@ abstract class AbstractIP extends AbstractEntry
      */
     protected function IPLongAnd($long1, $long2)
     {
-        $result = 0;
-        for ($bit = 0; $bit < static::NB_BITS; $bit++) {
-            $div = bcpow(2, $bit);
-            $and = bcmod(bcdiv($long1, $div, 0), 2) && bcmod(bcdiv($long2, $div, 0), 2);
-            $result = bcadd($result, bcmul($and, $div));
+        // The biggest power of 2 lowest than PHP_INT_MAX
+        // PHP_INT_MAX == 2 ** (PHP_INT_SIZE * 8 - 1) - 1
+        $divisor = 1 << (PHP_INT_SIZE * 8 - 2);
+        $result = '0';
+        $i = 0;
+
+        // As soon as a number is 0, the result of a bitwise-& cannot change.
+        while ($long1 && $long2) {
+            // Keep last bits og longs*
+            $chunk1 = bcmod($long1, $divisor);
+            $chunk2 = bcmod($long2, $divisor);
+            // Remove last bits of longs*
+            $long1 = bcdiv($long1, $divisor, 0);
+            $long2 = bcdiv($long2, $divisor, 0);
+
+            // Compare last bits
+            $chunkResult = (int) $chunk1 & (int) $chunk2;
+
+            // Add last bits comparison to global result
+            $result = bcadd($result, bcmul($chunkResult, bcpow($divisor, $i++)));
         }
+
         return $result;
     }
 
@@ -192,12 +208,28 @@ abstract class AbstractIP extends AbstractEntry
      */
     protected function IPLongOr($long1, $long2)
     {
-        $result = 0;
-        for ($bit = 0; $bit < static::NB_BITS; $bit++) {
-            $div = bcpow(2, $bit);
-            $and = bcmod(bcdiv($long1, $div, 0), 2) || bcmod(bcdiv($long2, $div, 0), 2);
-            $result = bcadd($result, bcmul($and, $div));
+        // The biggest power of 2 lowest than PHP_INT_MAX
+        // PHP_INT_MAX == 2 ** (PHP_INT_SIZE * 8 - 1) - 1
+        $divisor = 1 << (PHP_INT_SIZE * 8 - 2);
+        $result = '0';
+        $i = 0;
+
+        // Stop only when numbers have been completely treated
+        while ($long1 || $long2) {
+            // Keep last bits og longs*
+            $chunk1 = bcmod($long1, $divisor);
+            $chunk2 = bcmod($long2, $divisor);
+            // Remove last bits of longs*
+            $long1 = bcdiv($long1, $divisor, 0);
+            $long2 = bcdiv($long2, $divisor, 0);
+
+            // Compare last bits
+            $chunkResult = (int) $chunk1 | (int) $chunk2;
+
+            // Add last bits comparison to global result
+            $result = bcadd($result, bcmul($chunkResult, bcpow($divisor, $i++)));
         }
+
         return $result;
     }
 

--- a/Tests/Units/Entry/IPV6CIDR.php
+++ b/Tests/Units/Entry/IPV6CIDR.php
@@ -40,6 +40,11 @@ class IPV6CIDR extends atoum\test
             array('::/64', '0:0:0:0:ffff:ffff:ffff:ffff', true),
             array('::/64', '0:0:0:100:0:0:0:0',           false),
             array('::/64', '0:0:0:0:0:0:10:0',            true),
+            // Test with big ranges
+            array('ffff:0:0:0:0:0:0:0/16', 'ffff:0:0:0:0:0:0:0', false),
+            array('ffff:0:0:0:0:0:0:0/16', 'ffff:0:0:0:0:0:0:1', true),
+            array('ffff:0:0:0:0:0:0:0/16', 'fff0:0:0:0:0:0:0:1', false),
+            array('ffff:0:0:0:0:0:0:0/16', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', true),
         );
     }
 }


### PR DESCRIPTION
I detected a performance bottleneck when we check a big list of IPs. These 2 methods perform bitwise operations between IP, but **bit per bit**. It's really inneficient.

This solution use [Php bitwise operators](https://www.php.net/manual/en/language.operators.bitwise.php): IPs are split in several integers (the biggest possible integer according to `PHP_INT_MAX`) and operations are performed with native operators.

At most 2 iterations instead of 128… in our case, it's a game changer for performances 😄 👍 